### PR TITLE
Make indexing async with job polling; fix CORS for GitHub Pages; update UI upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,97 @@
 ![CI](https://github.com/vishalkoriyalearning/rag-serve/actions/workflows/ci.yml/badge.svg)
-# 🚀 RAG-Serve — Retrieval Augmented Generation API
+# RAG-Serve - Retrieval Augmented Generation API
 
-**RAG-Serve** is a production-ready, containerized **RAG (Retrieval-Augmented Generation)** system built with **FastAPI**, **FAISS**, **Sentence-Transformers**, and **LLMs (OpenAI + Ollama fallback)**.
+RAG-Serve is a production-oriented, containerized RAG (Retrieval-Augmented Generation) system that demonstrates end-to-end AI application engineering. It ingests documents, builds a FAISS index, retrieves relevant context, and generates grounded answers using configurable LLM providers.
 
-It ingests documents → chunks them → builds embeddings → stores a FAISS vector index → retrieves relevant context → and generates answers using LLMs.
+This repository is a showcase of:
 
-This project demonstrates:
-
-* Backend/API engineering
-* RAG pipeline architecture
-* Hybrid LLM usage (Cloud + Local)
-* FAISS vector search
-* Docker & CI/CD
-* Test-driven workflow
+* Backend and API engineering with FastAPI
+* RAG pipeline design and retrieval evaluation basics
+* Vector search with FAISS
+* Multi-provider LLM integration (OpenAI, Gemini)
+* CI/CD and Docker-based workflows
+* Practical, testable system design
 
 ---
 
-## 📦 Features
+## Live Deployment
 
-* **Document Ingestion** (`/ingest`, `/index-doc`)
-* **Text Extraction** from PDF & TXT
-* **Chunking** with overlap
-* **Embeddings** using `sentence-transformers`
-* **FAISS Vector Store** for fast retrieval
-* **Query API** for semantic search
-* **Generate API** using:
-
-  * **OpenAI (Primary)**
-  * **Ollama Llama3.2:1b (Fallback)**
-* **Dockerized Deployment** (API + Ollama)
-* **GitHub Actions CI**
-
-  * Linting (Ruff)
-  * Unit tests (PyTest)
-  * Docker build
-* **Simple, clean architecture**
+* Backend API deployed on Render
+* Frontend UI hosted on GitHub Pages https://vishalkoriyalearning.github.io/rag-serve/
 
 ---
 
-## 🧱 Tech Stack
+## Features
 
-* **FastAPI** — API framework
-* **FAISS** — vector similarity search
-* **Sentence-Transformers** — embedding generation
-* **OpenAI GPT models** — generation (optional)
-* **Ollama Llama3.2:1b** — local generation fallback
-* **Docker + Docker Compose**
-* **GitHub Actions (CI)**
-* **PyTest + Ruff**
+* Document ingestion (`/ingest`, `/index-doc`)
+* PDF and TXT extraction
+* Chunking with overlap for retrieval quality
+* Embeddings using `sentence-transformers`
+* FAISS vector store for fast similarity search
+* Semantic search API (`/query`)
+* Answer generation API (`/generate`) with provider routing
+* Minimal UI for document upload and chat-style Q&A
+* GitHub Actions CI (lint, tests, Docker build)
 
 ---
 
-## 📂 Project Structure
+## Architecture Overview
+
+1. Ingest a document and extract text
+2. Chunk and embed text
+3. Build and persist FAISS index and chunks
+4. For a query, retrieve top-k relevant chunks
+5. Build a context-aware prompt
+6. Generate an answer with the selected LLM provider
+
+---
+
+## Sequence Diagram (Mermaid)
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as Web UI (GitHub Pages)
+    participant API as FastAPI (Render)
+    participant Emb as Embeddings
+    participant VS as FAISS Index
+    participant LLM as LLM Provider
+
+    User->>UI: Upload document / Ask question
+    UI->>API: POST /ingest or /generate?llm_provider=...
+    API->>Emb: Embed chunks or query
+    API->>VS: Store or search vectors
+    VS-->>API: Top-k chunks
+    API->>LLM: Generate answer with context
+    LLM-->>API: Answer text
+    API-->>UI: Response
+```
+
+---
+
+## Tech Stack
+
+* FastAPI
+* FAISS
+* Sentence-Transformers
+* OpenAI and Gemini LLMs
+* Docker and Docker Compose
+* GitHub Actions CI
+* PyTest and Ruff
+
+---
+
+## Project Structure
 
 ```
 rag-serve/
 ├─ app/
-│  ├─ api/
 │  ├─ core/         # chunker, embeddings, vectorstore, generator
 │  ├─ utils/        # pdf text extraction
-│  └─ main.py       # FastAPI root
+│  └─ main.py       # FastAPI entrypoint
+├─ client/          # static UI
 ├─ configs/         # model configs
-├─ storage/         # FAISS + metadata
+├─ storage/         # FAISS index and metadata
 ├─ tests/           # pytest unit tests
 ├─ docker-compose.yml
 ├─ Dockerfile
@@ -70,113 +100,109 @@ rag-serve/
 
 ---
 
-## 🚀 Getting Started (Local)
+## Getting Started (Local)
 
-### 1. Create virtual environment
+1. Create virtual environment
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 ```
 
-### 2. Install dependencies
+2. Install dependencies
 
 ```bash
 pip install -r requirements.txt
 ```
 
-### 3. Run FastAPI
+3. Configure environment
+
+```bash
+copy .env.example .env   # Windows
+# cp .env.example .env   # macOS/Linux
+```
+
+4. Run FastAPI
 
 ```bash
 uvicorn app.main:app --reload
 ```
 
-Visit → [http://localhost:8000/docs](http://localhost:8000/docs)
+Visit http://localhost:8000/docs
 
 ---
 
-## 🐳 Run with Docker (Recommended)
+## Configuration
 
-### 1. Build + start services (API + Ollama)
+Set your API keys in `.env` or provide them at runtime:
+
+* `OPENAI_API_KEY`, `OPENAI_MODEL`
+* `GEMINI_API_KEY`, `GEMINI_MODEL`
+* `EMBEDDING_MODEL`, `TOP_K`
+
+The UI sends the provider as `llm_provider` with values:
+
+* `openai`
+* `gemini`
+
+---
+
+## API Endpoints
+
+* `GET /health` - health check
+* `GET /metrics` - Prometheus metrics
+* `POST /ingest` - upload a document
+* `POST /index-doc` - build the FAISS index
+* `POST /query` - semantic search
+* `POST /generate` - RAG + LLM answer
+
+Example request:
 
 ```bash
-docker-compose up --build
-```
-
-### 2. Pull Ollama model (inside container)
-
-```bash
-docker exec -it ollama ollama pull llama3.2:1b
+curl -X POST "http://localhost:8000/generate?llm_provider=openai" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: <your_key>" \
+  -d "{\"query\":\"What is this document about?\",\"top_k\":3}"
 ```
 
 ---
 
-## 🧪 Testing
+## Frontend UI
 
-Run all unit tests:
+The UI is a static client in `client/`:
+
+* Select LLM provider (OpenAI or Gemini)
+* Enter API key (stored locally in the browser)
+* Upload documents and ask questions
+
+The UI points to the deployed backend by default and can be adjusted in `client/script.js`.
+
+---
+
+## Testing
 
 ```bash
 pytest -q
-```
-
-Lint the code:
-
-```bash
 ruff check .
 ```
 
 ---
 
-## 🔌 API Endpoints
+## CI/CD
 
-### ✔ Health Check
+GitHub Actions runs:
 
-`GET /health`
-
-### ✔ Ingest Document
-
-`POST /ingest`
-
-### ✔ Build Index
-
-`POST /index-doc`
-
-### ✔ Semantic Search
-
-`POST /query`
-
-### ✔ RAG + LLM Answer
-
-`POST /generate`
-Uses **OpenAI → fallback to Ollama**
+* Ruff linting
+* PyTest unit tests
+* Docker build checks
 
 ---
 
-## 🔄 CI/CD (GitHub Actions)
+## Roadmap Ideas
 
-* Automatic linting
-* Automatic tests
-* Automatic Docker build
-* Status badge included in this repo
-
----
-
-## 📘 Notes
-
-This project is built as a **learning-by-doing** portfolio system to demonstrate knowledge of:
-
-* AI engineering
-* Modern backend design
-* Vector search
-* LLM integrations
-* Dockerized microservices
-* CI/CD automation
-
-It is structured to be easily extended with:
-
-* Reranking
-* Chat memory
-* UI client
-* API authentication
-* MLflow experiment tracking
+* Reranking or hybrid retrieval
+* Multi-document chat memory
+* API auth and rate limiting
+* Usage analytics dashboard
+* Experiment tracking
 

--- a/app/core/indexing.py
+++ b/app/core/indexing.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from uuid import uuid4
+from fastapi import BackgroundTasks
+
+from app.core.chunker import chunk_text
+from app.core.embeddings import embed_chunks
+from app.core.vectorstore import build_faiss_index, save_faiss_index, save_chunks
+from app.utils.logging import get_logger
+from app.utils.pdf_text import extract_pdf_text
+
+logger = get_logger()
+
+index_jobs: dict[str, dict] = {}
+
+
+def _index_document_task(filename: str, content: bytes, job_id: str) -> None:
+    try:
+        logger.info(f"Index-doc background job started. job_id={job_id}, file={filename}")
+        if filename.endswith(".pdf"):
+            logger.debug("Extracting text from PDF file.")
+            text = extract_pdf_text(content)
+        else:
+            logger.debug("Decoding text from non-PDF file.")
+            text = content.decode("utf-8", errors="ignore")
+
+        logger.info("Chunking text.")
+        chunks = chunk_text(text)
+        logger.info(f"Text chunked into {len(chunks)} chunks.")
+
+        logger.info("Embedding chunks.")
+        embeddings = embed_chunks(chunks)
+        logger.info(
+            "Chunks embedded. Embedding dimension: "
+            f"{embeddings.shape[1] if hasattr(embeddings, 'shape') else 'unknown'}."
+        )
+
+        logger.info("Building FAISS index.")
+        index = build_faiss_index(embeddings)
+
+        logger.info("Saving FAISS index and chunks metadata.")
+        save_faiss_index(index)
+        save_chunks(chunks)
+
+        index_jobs[job_id] = {
+            "status": "completed",
+            "chunks_indexed": len(chunks),
+            "embedding_dim": embeddings.shape[1] if hasattr(embeddings, "shape") else None,
+            "faiss_saved": True,
+        }
+        logger.info(f"Indexing complete. job_id={job_id}")
+    except Exception as e:
+        logger.error(f"Index-doc background job failed. job_id={job_id} error={e}")
+        index_jobs[job_id] = {"status": "failed", "error": str(e)}
+
+
+def start_index_job(background_tasks: BackgroundTasks, filename: str, content: bytes) -> str:
+    job_id = str(uuid4())
+    index_jobs[job_id] = {"status": "queued", "file": filename}
+    background_tasks.add_task(_index_document_task, filename, content, job_id)
+    return job_id
+
+
+def get_index_job(job_id: str) -> dict | None:
+    return index_jobs.get(job_id)


### PR DESCRIPTION
**Summary**
This PR will improve production reliability on Render by moving document indexing off the request thread, add a job status API for progress polling, fix CORS so the GitHub Pages UI can reach the backend, and update the UI to handle async indexing correctly.

**Planned Changes**
1. **Backend**
   - Update CORS middleware to explicitly allow:
     - `https://vishalkoriyalearning.github.io`
     - local dev origins
   - Change `POST /index-doc` to return `202` + `job_id` and start indexing in a background task.
   - Add `GET /index-status/{job_id}` endpoint.
   - Move indexing/background job logic into a dedicated module (e.g. `app/core/indexing.py`) to keep `app/main.py` thin.
2. **Frontend**
   - Update upload flow to poll `/index-status/{job_id}` and render “queued/running/completed/failed” states.
   - Keep backward compatibility if the endpoint still returns synchronous payloads.
3. **Docs**
   - Update README sequence diagram and examples to reflect async indexing and Render cold-start.

**Why**
1. Prevent request timeouts / 502s during embedding on Render free tier.
2. Unblock cross-origin calls from GitHub Pages.
3. Improve UX and make the system feel production-grade.

**Testing Plan**
1. Local: upload a PDF and confirm indexing completes and is queryable.
2. Local: verify CORS headers from GitHub Pages origin (or by simulating with curl).
3. Render: confirm `/index-doc` returns `202` consistently and UI completes indexing without 502s.
4. Run `pytest -q` and `ruff check .`.

Closes #2 